### PR TITLE
[iOS] FEAT: 상품 목록 리스트 collection view 및 관련 view controller 작성

### DIFF
--- a/ios/Daangn/Daangn.xcodeproj/project.pbxproj
+++ b/ios/Daangn/Daangn.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		F4029F392A3B5B4500ECEABD /* LoadCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F372A3B5B4500ECEABD /* LoadCollectionViewCell.swift */; };
 		F4029F3D2A3B5CE700ECEABD /* ProductListCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F3B2A3B5CE700ECEABD /* ProductListCollectionView.swift */; };
 		F4029F3E2A3B5CE700ECEABD /* ProductListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F3C2A3B5CE700ECEABD /* ProductListDataSource.swift */; };
+		F4029F422A3B5D6E00ECEABD /* CateogryFilterDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F3F2A3B5D6E00ECEABD /* CateogryFilterDataSource.swift */; };
+		F4029F432A3B5D6E00ECEABD /* CategoryFilterCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F402A3B5D6E00ECEABD /* CategoryFilterCollectionViewCell.swift */; };
+		F4029F442A3B5D6E00ECEABD /* CategoryFilterCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F412A3B5D6E00ECEABD /* CategoryFilterCollectionView.swift */; };
+		F4029F472A3B5D9900ECEABD /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F462A3B5D9900ECEABD /* Category.swift */; };
 		F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C12A305FAF00609856 /* AppDelegate.swift */; };
 		F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C32A305FAF00609856 /* SceneDelegate.swift */; };
 		F49F98CB2A305FB000609856 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F49F98CA2A305FB000609856 /* Assets.xcassets */; };
@@ -48,6 +52,10 @@
 		F4029F372A3B5B4500ECEABD /* LoadCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadCollectionViewCell.swift; sourceTree = "<group>"; };
 		F4029F3B2A3B5CE700ECEABD /* ProductListCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductListCollectionView.swift; sourceTree = "<group>"; };
 		F4029F3C2A3B5CE700ECEABD /* ProductListDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductListDataSource.swift; sourceTree = "<group>"; };
+		F4029F3F2A3B5D6E00ECEABD /* CateogryFilterDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CateogryFilterDataSource.swift; sourceTree = "<group>"; };
+		F4029F402A3B5D6E00ECEABD /* CategoryFilterCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryFilterCollectionViewCell.swift; sourceTree = "<group>"; };
+		F4029F412A3B5D6E00ECEABD /* CategoryFilterCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryFilterCollectionView.swift; sourceTree = "<group>"; };
+		F4029F462A3B5D9900ECEABD /* Category.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
 		F49F98BE2A305FAF00609856 /* Daangn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Daangn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F49F98C12A305FAF00609856 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F49F98C32A305FAF00609856 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -120,6 +128,7 @@
 		F4029F332A3B572000ECEABD /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				F4029F462A3B5D9900ECEABD /* Category.swift */,
 				F4029F312A3B571300ECEABD /* ProductState.swift */,
 			);
 			path = Model;
@@ -134,6 +143,16 @@
 				F4029F362A3B5B4500ECEABD /* ProductListCollectionViewCell.swift */,
 			);
 			path = ProductList;
+			sourceTree = "<group>";
+		};
+		F4029F452A3B5D7300ECEABD /* CategoryFilter */ = {
+			isa = PBXGroup;
+			children = (
+				F4029F412A3B5D6E00ECEABD /* CategoryFilterCollectionView.swift */,
+				F4029F3F2A3B5D6E00ECEABD /* CateogryFilterDataSource.swift */,
+				F4029F402A3B5D6E00ECEABD /* CategoryFilterCollectionViewCell.swift */,
+			);
+			path = CategoryFilter;
 			sourceTree = "<group>";
 		};
 		F49F98B52A305FAF00609856 = {
@@ -164,6 +183,7 @@
 				F4029F332A3B572000ECEABD /* Model */,
 				F4029F242A3B54FB00ECEABD /* Extension */,
 				F4029F3A2A3B5B4A00ECEABD /* ProductList */,
+				F4029F452A3B5D7300ECEABD /* CategoryFilter */,
 			);
 			path = Daangn;
 			sourceTree = "<group>";
@@ -283,6 +303,7 @@
 			files = (
 				F4029F3E2A3B5CE700ECEABD /* ProductListDataSource.swift in Sources */,
 				4FE271522A31B23A0002AE35 /* ImageMapper.swift in Sources */,
+				F4029F432A3B5D6E00ECEABD /* CategoryFilterCollectionViewCell.swift in Sources */,
 				F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */,
 				F4029F382A3B5B4500ECEABD /* ProductListCollectionViewCell.swift in Sources */,
 				F4029F292A3B569B00ECEABD /* ProductListImageView.swift in Sources */,
@@ -292,11 +313,14 @@
 				F4AEA7F42A3617D200B00B03 /* TabBarController.swift in Sources */,
 				F4029F352A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift in Sources */,
 				F4029F2E2A3B56D300ECEABD /* PaddedLabel.swift in Sources */,
+				F4029F442A3B5D6E00ECEABD /* CategoryFilterCollectionView.swift in Sources */,
 				F4029F2C2A3B56CB00ECEABD /* BorderView.swift in Sources */,
+				F4029F472A3B5D9900ECEABD /* Category.swift in Sources */,
 				F4029F322A3B571300ECEABD /* ProductState.swift in Sources */,
 				F4029F3D2A3B5CE700ECEABD /* ProductListCollectionView.swift in Sources */,
 				F4029F272A3B557500ECEABD /* UILabel+style.swift in Sources */,
 				F4029F212A3B54D200ECEABD /* Radius.swift in Sources */,
+				F4029F422A3B5D6E00ECEABD /* CateogryFilterDataSource.swift in Sources */,
 				F4029F392A3B5B4500ECEABD /* LoadCollectionViewCell.swift in Sources */,
 				4FE271542A31C0F50002AE35 /* ColorStyle.swift in Sources */,
 				4FE271562A31C4820002AE35 /* FontStyle.swift in Sources */,

--- a/ios/Daangn/Daangn.xcodeproj/project.pbxproj
+++ b/ios/Daangn/Daangn.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		F4029F302A3B56D800ECEABD /* ProductStateBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F2F2A3B56D800ECEABD /* ProductStateBadge.swift */; };
 		F4029F322A3B571300ECEABD /* ProductState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F312A3B571300ECEABD /* ProductState.swift */; };
 		F4029F352A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F342A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift */; };
+		F4029F382A3B5B4500ECEABD /* ProductListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F362A3B5B4500ECEABD /* ProductListCollectionViewCell.swift */; };
+		F4029F392A3B5B4500ECEABD /* LoadCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F372A3B5B4500ECEABD /* LoadCollectionViewCell.swift */; };
 		F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C12A305FAF00609856 /* AppDelegate.swift */; };
 		F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C32A305FAF00609856 /* SceneDelegate.swift */; };
 		F49F98CB2A305FB000609856 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F49F98CA2A305FB000609856 /* Assets.xcassets */; };
@@ -40,6 +42,8 @@
 		F4029F2F2A3B56D800ECEABD /* ProductStateBadge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductStateBadge.swift; sourceTree = "<group>"; };
 		F4029F312A3B571300ECEABD /* ProductState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductState.swift; sourceTree = "<group>"; };
 		F4029F342A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionViewLayout+layouts.swift"; sourceTree = "<group>"; };
+		F4029F362A3B5B4500ECEABD /* ProductListCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductListCollectionViewCell.swift; sourceTree = "<group>"; };
+		F4029F372A3B5B4500ECEABD /* LoadCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadCollectionViewCell.swift; sourceTree = "<group>"; };
 		F49F98BE2A305FAF00609856 /* Daangn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Daangn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F49F98C12A305FAF00609856 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F49F98C32A305FAF00609856 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -117,6 +121,15 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		F4029F3A2A3B5B4A00ECEABD /* ProductList */ = {
+			isa = PBXGroup;
+			children = (
+				F4029F372A3B5B4500ECEABD /* LoadCollectionViewCell.swift */,
+				F4029F362A3B5B4500ECEABD /* ProductListCollectionViewCell.swift */,
+			);
+			path = ProductList;
+			sourceTree = "<group>";
+		};
 		F49F98B52A305FAF00609856 = {
 			isa = PBXGroup;
 			children = (
@@ -144,6 +157,7 @@
 				F4029F2A2A3B56AE00ECEABD /* Component */,
 				F4029F332A3B572000ECEABD /* Model */,
 				F4029F242A3B54FB00ECEABD /* Extension */,
+				F4029F3A2A3B5B4A00ECEABD /* ProductList */,
 			);
 			path = Daangn;
 			sourceTree = "<group>";
@@ -263,6 +277,7 @@
 			files = (
 				4FE271522A31B23A0002AE35 /* ImageMapper.swift in Sources */,
 				F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */,
+				F4029F382A3B5B4500ECEABD /* ProductListCollectionViewCell.swift in Sources */,
 				F4029F292A3B569B00ECEABD /* ProductListImageView.swift in Sources */,
 				F4029F232A3B54F800ECEABD /* UIView+Radius.swift in Sources */,
 				F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */,
@@ -274,6 +289,7 @@
 				F4029F322A3B571300ECEABD /* ProductState.swift in Sources */,
 				F4029F272A3B557500ECEABD /* UILabel+style.swift in Sources */,
 				F4029F212A3B54D200ECEABD /* Radius.swift in Sources */,
+				F4029F392A3B5B4500ECEABD /* LoadCollectionViewCell.swift in Sources */,
 				4FE271542A31C0F50002AE35 /* ColorStyle.swift in Sources */,
 				4FE271562A31C4820002AE35 /* FontStyle.swift in Sources */,
 			);

--- a/ios/Daangn/Daangn.xcodeproj/project.pbxproj
+++ b/ios/Daangn/Daangn.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		4FE271562A31C4820002AE35 /* FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE271552A31C4820002AE35 /* FontStyle.swift */; };
 		F4029F212A3B54D200ECEABD /* Radius.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F202A3B54D200ECEABD /* Radius.swift */; };
 		F4029F232A3B54F800ECEABD /* UIView+Radius.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F222A3B54F800ECEABD /* UIView+Radius.swift */; };
+		F4029F272A3B557500ECEABD /* UILabel+style.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F262A3B557500ECEABD /* UILabel+style.swift */; };
 		F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C12A305FAF00609856 /* AppDelegate.swift */; };
 		F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C32A305FAF00609856 /* SceneDelegate.swift */; };
 		F49F98CB2A305FB000609856 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F49F98CA2A305FB000609856 /* Assets.xcassets */; };
@@ -26,6 +27,7 @@
 		4FE271552A31C4820002AE35 /* FontStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontStyle.swift; sourceTree = "<group>"; };
 		F4029F202A3B54D200ECEABD /* Radius.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Radius.swift; sourceTree = "<group>"; };
 		F4029F222A3B54F800ECEABD /* UIView+Radius.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Radius.swift"; sourceTree = "<group>"; };
+		F4029F262A3B557500ECEABD /* UILabel+style.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UILabel+style.swift"; sourceTree = "<group>"; };
 		F49F98BE2A305FAF00609856 /* Daangn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Daangn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F49F98C12A305FAF00609856 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F49F98C32A305FAF00609856 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 			isa = PBXGroup;
 			children = (
 				F4029F222A3B54F800ECEABD /* UIView+Radius.swift */,
+				F4029F262A3B557500ECEABD /* UILabel+style.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -229,6 +232,7 @@
 				F4029F232A3B54F800ECEABD /* UIView+Radius.swift in Sources */,
 				F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */,
 				F4AEA7F42A3617D200B00B03 /* TabBarController.swift in Sources */,
+				F4029F272A3B557500ECEABD /* UILabel+style.swift in Sources */,
 				F4029F212A3B54D200ECEABD /* Radius.swift in Sources */,
 				4FE271542A31C0F50002AE35 /* ColorStyle.swift in Sources */,
 				4FE271562A31C4820002AE35 /* FontStyle.swift in Sources */,

--- a/ios/Daangn/Daangn.xcodeproj/project.pbxproj
+++ b/ios/Daangn/Daangn.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		F4029F2E2A3B56D300ECEABD /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F2D2A3B56D300ECEABD /* PaddedLabel.swift */; };
 		F4029F302A3B56D800ECEABD /* ProductStateBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F2F2A3B56D800ECEABD /* ProductStateBadge.swift */; };
 		F4029F322A3B571300ECEABD /* ProductState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F312A3B571300ECEABD /* ProductState.swift */; };
+		F4029F352A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F342A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift */; };
 		F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C12A305FAF00609856 /* AppDelegate.swift */; };
 		F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C32A305FAF00609856 /* SceneDelegate.swift */; };
 		F49F98CB2A305FB000609856 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F49F98CA2A305FB000609856 /* Assets.xcassets */; };
@@ -38,6 +39,7 @@
 		F4029F2D2A3B56D300ECEABD /* PaddedLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaddedLabel.swift; sourceTree = "<group>"; };
 		F4029F2F2A3B56D800ECEABD /* ProductStateBadge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductStateBadge.swift; sourceTree = "<group>"; };
 		F4029F312A3B571300ECEABD /* ProductState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductState.swift; sourceTree = "<group>"; };
+		F4029F342A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionViewLayout+layouts.swift"; sourceTree = "<group>"; };
 		F49F98BE2A305FAF00609856 /* Daangn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Daangn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F49F98C12A305FAF00609856 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F49F98C32A305FAF00609856 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -83,6 +85,7 @@
 			children = (
 				F4029F222A3B54F800ECEABD /* UIView+Radius.swift */,
 				F4029F262A3B557500ECEABD /* UILabel+style.swift */,
+				F4029F342A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -265,6 +268,7 @@
 				F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */,
 				F4029F302A3B56D800ECEABD /* ProductStateBadge.swift in Sources */,
 				F4AEA7F42A3617D200B00B03 /* TabBarController.swift in Sources */,
+				F4029F352A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift in Sources */,
 				F4029F2E2A3B56D300ECEABD /* PaddedLabel.swift in Sources */,
 				F4029F2C2A3B56CB00ECEABD /* BorderView.swift in Sources */,
 				F4029F322A3B571300ECEABD /* ProductState.swift in Sources */,

--- a/ios/Daangn/Daangn.xcodeproj/project.pbxproj
+++ b/ios/Daangn/Daangn.xcodeproj/project.pbxproj
@@ -27,6 +27,10 @@
 		F4029F432A3B5D6E00ECEABD /* CategoryFilterCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F402A3B5D6E00ECEABD /* CategoryFilterCollectionViewCell.swift */; };
 		F4029F442A3B5D6E00ECEABD /* CategoryFilterCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F412A3B5D6E00ECEABD /* CategoryFilterCollectionView.swift */; };
 		F4029F472A3B5D9900ECEABD /* Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F462A3B5D9900ECEABD /* Category.swift */; };
+		F4029F4C2A3B61A400ECEABD /* TempHomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F482A3B61A400ECEABD /* TempHomeViewController.swift */; };
+		F4029F4D2A3B61A400ECEABD /* TempSalesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F492A3B61A400ECEABD /* TempSalesViewController.swift */; };
+		F4029F4E2A3B61A400ECEABD /* TempWishListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F4A2A3B61A400ECEABD /* TempWishListViewController.swift */; };
+		F4029F4F2A3B61A400ECEABD /* TempTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F4B2A3B61A400ECEABD /* TempTabBarController.swift */; };
 		F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C12A305FAF00609856 /* AppDelegate.swift */; };
 		F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C32A305FAF00609856 /* SceneDelegate.swift */; };
 		F49F98CB2A305FB000609856 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F49F98CA2A305FB000609856 /* Assets.xcassets */; };
@@ -56,6 +60,10 @@
 		F4029F402A3B5D6E00ECEABD /* CategoryFilterCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryFilterCollectionViewCell.swift; sourceTree = "<group>"; };
 		F4029F412A3B5D6E00ECEABD /* CategoryFilterCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryFilterCollectionView.swift; sourceTree = "<group>"; };
 		F4029F462A3B5D9900ECEABD /* Category.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Category.swift; sourceTree = "<group>"; };
+		F4029F482A3B61A400ECEABD /* TempHomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TempHomeViewController.swift; sourceTree = "<group>"; };
+		F4029F492A3B61A400ECEABD /* TempSalesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TempSalesViewController.swift; sourceTree = "<group>"; };
+		F4029F4A2A3B61A400ECEABD /* TempWishListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TempWishListViewController.swift; sourceTree = "<group>"; };
+		F4029F4B2A3B61A400ECEABD /* TempTabBarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TempTabBarController.swift; sourceTree = "<group>"; };
 		F49F98BE2A305FAF00609856 /* Daangn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Daangn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F49F98C12A305FAF00609856 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F49F98C32A305FAF00609856 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -155,6 +163,17 @@
 			path = CategoryFilter;
 			sourceTree = "<group>";
 		};
+		F4029F502A3B61AB00ECEABD /* TempVC */ = {
+			isa = PBXGroup;
+			children = (
+				F4029F4B2A3B61A400ECEABD /* TempTabBarController.swift */,
+				F4029F482A3B61A400ECEABD /* TempHomeViewController.swift */,
+				F4029F492A3B61A400ECEABD /* TempSalesViewController.swift */,
+				F4029F4A2A3B61A400ECEABD /* TempWishListViewController.swift */,
+			);
+			path = TempVC;
+			sourceTree = "<group>";
+		};
 		F49F98B52A305FAF00609856 = {
 			isa = PBXGroup;
 			children = (
@@ -179,9 +198,10 @@
 				F49F98D62A30629600609856 /* Resource */,
 				F49F98D52A30626000609856 /* Supporting Files */,
 				F4029F252A3B550900ECEABD /* Common */,
+				F4029F242A3B54FB00ECEABD /* Extension */,
 				F4029F2A2A3B56AE00ECEABD /* Component */,
 				F4029F332A3B572000ECEABD /* Model */,
-				F4029F242A3B54FB00ECEABD /* Extension */,
+				F4029F502A3B61AB00ECEABD /* TempVC */,
 				F4029F3A2A3B5B4A00ECEABD /* ProductList */,
 				F4029F452A3B5D7300ECEABD /* CategoryFilter */,
 			);
@@ -307,15 +327,19 @@
 				F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */,
 				F4029F382A3B5B4500ECEABD /* ProductListCollectionViewCell.swift in Sources */,
 				F4029F292A3B569B00ECEABD /* ProductListImageView.swift in Sources */,
+				F4029F4E2A3B61A400ECEABD /* TempWishListViewController.swift in Sources */,
 				F4029F232A3B54F800ECEABD /* UIView+Radius.swift in Sources */,
 				F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */,
 				F4029F302A3B56D800ECEABD /* ProductStateBadge.swift in Sources */,
 				F4AEA7F42A3617D200B00B03 /* TabBarController.swift in Sources */,
 				F4029F352A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift in Sources */,
+				F4029F4D2A3B61A400ECEABD /* TempSalesViewController.swift in Sources */,
 				F4029F2E2A3B56D300ECEABD /* PaddedLabel.swift in Sources */,
 				F4029F442A3B5D6E00ECEABD /* CategoryFilterCollectionView.swift in Sources */,
+				F4029F4C2A3B61A400ECEABD /* TempHomeViewController.swift in Sources */,
 				F4029F2C2A3B56CB00ECEABD /* BorderView.swift in Sources */,
 				F4029F472A3B5D9900ECEABD /* Category.swift in Sources */,
+				F4029F4F2A3B61A400ECEABD /* TempTabBarController.swift in Sources */,
 				F4029F322A3B571300ECEABD /* ProductState.swift in Sources */,
 				F4029F3D2A3B5CE700ECEABD /* ProductListCollectionView.swift in Sources */,
 				F4029F272A3B557500ECEABD /* UILabel+style.swift in Sources */,

--- a/ios/Daangn/Daangn.xcodeproj/project.pbxproj
+++ b/ios/Daangn/Daangn.xcodeproj/project.pbxproj
@@ -13,6 +13,11 @@
 		F4029F212A3B54D200ECEABD /* Radius.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F202A3B54D200ECEABD /* Radius.swift */; };
 		F4029F232A3B54F800ECEABD /* UIView+Radius.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F222A3B54F800ECEABD /* UIView+Radius.swift */; };
 		F4029F272A3B557500ECEABD /* UILabel+style.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F262A3B557500ECEABD /* UILabel+style.swift */; };
+		F4029F292A3B569B00ECEABD /* ProductListImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F282A3B569B00ECEABD /* ProductListImageView.swift */; };
+		F4029F2C2A3B56CB00ECEABD /* BorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F2B2A3B56CB00ECEABD /* BorderView.swift */; };
+		F4029F2E2A3B56D300ECEABD /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F2D2A3B56D300ECEABD /* PaddedLabel.swift */; };
+		F4029F302A3B56D800ECEABD /* ProductStateBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F2F2A3B56D800ECEABD /* ProductStateBadge.swift */; };
+		F4029F322A3B571300ECEABD /* ProductState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F312A3B571300ECEABD /* ProductState.swift */; };
 		F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C12A305FAF00609856 /* AppDelegate.swift */; };
 		F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C32A305FAF00609856 /* SceneDelegate.swift */; };
 		F49F98CB2A305FB000609856 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F49F98CA2A305FB000609856 /* Assets.xcassets */; };
@@ -28,6 +33,11 @@
 		F4029F202A3B54D200ECEABD /* Radius.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Radius.swift; sourceTree = "<group>"; };
 		F4029F222A3B54F800ECEABD /* UIView+Radius.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Radius.swift"; sourceTree = "<group>"; };
 		F4029F262A3B557500ECEABD /* UILabel+style.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UILabel+style.swift"; sourceTree = "<group>"; };
+		F4029F282A3B569B00ECEABD /* ProductListImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductListImageView.swift; sourceTree = "<group>"; };
+		F4029F2B2A3B56CB00ECEABD /* BorderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BorderView.swift; sourceTree = "<group>"; };
+		F4029F2D2A3B56D300ECEABD /* PaddedLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaddedLabel.swift; sourceTree = "<group>"; };
+		F4029F2F2A3B56D800ECEABD /* ProductStateBadge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductStateBadge.swift; sourceTree = "<group>"; };
+		F4029F312A3B571300ECEABD /* ProductState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductState.swift; sourceTree = "<group>"; };
 		F49F98BE2A305FAF00609856 /* Daangn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Daangn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F49F98C12A305FAF00609856 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F49F98C32A305FAF00609856 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -85,6 +95,25 @@
 			path = Common;
 			sourceTree = "<group>";
 		};
+		F4029F2A2A3B56AE00ECEABD /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				F4029F282A3B569B00ECEABD /* ProductListImageView.swift */,
+				F4029F2B2A3B56CB00ECEABD /* BorderView.swift */,
+				F4029F2D2A3B56D300ECEABD /* PaddedLabel.swift */,
+				F4029F2F2A3B56D800ECEABD /* ProductStateBadge.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
+		F4029F332A3B572000ECEABD /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				F4029F312A3B571300ECEABD /* ProductState.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		F49F98B52A305FAF00609856 = {
 			isa = PBXGroup;
 			children = (
@@ -109,6 +138,8 @@
 				F49F98D62A30629600609856 /* Resource */,
 				F49F98D52A30626000609856 /* Supporting Files */,
 				F4029F252A3B550900ECEABD /* Common */,
+				F4029F2A2A3B56AE00ECEABD /* Component */,
+				F4029F332A3B572000ECEABD /* Model */,
 				F4029F242A3B54FB00ECEABD /* Extension */,
 			);
 			path = Daangn;
@@ -229,9 +260,14 @@
 			files = (
 				4FE271522A31B23A0002AE35 /* ImageMapper.swift in Sources */,
 				F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */,
+				F4029F292A3B569B00ECEABD /* ProductListImageView.swift in Sources */,
 				F4029F232A3B54F800ECEABD /* UIView+Radius.swift in Sources */,
 				F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */,
+				F4029F302A3B56D800ECEABD /* ProductStateBadge.swift in Sources */,
 				F4AEA7F42A3617D200B00B03 /* TabBarController.swift in Sources */,
+				F4029F2E2A3B56D300ECEABD /* PaddedLabel.swift in Sources */,
+				F4029F2C2A3B56CB00ECEABD /* BorderView.swift in Sources */,
+				F4029F322A3B571300ECEABD /* ProductState.swift in Sources */,
 				F4029F272A3B557500ECEABD /* UILabel+style.swift in Sources */,
 				F4029F212A3B54D200ECEABD /* Radius.swift in Sources */,
 				4FE271542A31C0F50002AE35 /* ColorStyle.swift in Sources */,

--- a/ios/Daangn/Daangn.xcodeproj/project.pbxproj
+++ b/ios/Daangn/Daangn.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		F4029F352A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F342A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift */; };
 		F4029F382A3B5B4500ECEABD /* ProductListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F362A3B5B4500ECEABD /* ProductListCollectionViewCell.swift */; };
 		F4029F392A3B5B4500ECEABD /* LoadCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F372A3B5B4500ECEABD /* LoadCollectionViewCell.swift */; };
+		F4029F3D2A3B5CE700ECEABD /* ProductListCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F3B2A3B5CE700ECEABD /* ProductListCollectionView.swift */; };
+		F4029F3E2A3B5CE700ECEABD /* ProductListDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F3C2A3B5CE700ECEABD /* ProductListDataSource.swift */; };
 		F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C12A305FAF00609856 /* AppDelegate.swift */; };
 		F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C32A305FAF00609856 /* SceneDelegate.swift */; };
 		F49F98CB2A305FB000609856 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F49F98CA2A305FB000609856 /* Assets.xcassets */; };
@@ -44,6 +46,8 @@
 		F4029F342A3B5A8200ECEABD /* CollectionViewLayout+layouts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionViewLayout+layouts.swift"; sourceTree = "<group>"; };
 		F4029F362A3B5B4500ECEABD /* ProductListCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductListCollectionViewCell.swift; sourceTree = "<group>"; };
 		F4029F372A3B5B4500ECEABD /* LoadCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadCollectionViewCell.swift; sourceTree = "<group>"; };
+		F4029F3B2A3B5CE700ECEABD /* ProductListCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductListCollectionView.swift; sourceTree = "<group>"; };
+		F4029F3C2A3B5CE700ECEABD /* ProductListDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductListDataSource.swift; sourceTree = "<group>"; };
 		F49F98BE2A305FAF00609856 /* Daangn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Daangn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F49F98C12A305FAF00609856 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F49F98C32A305FAF00609856 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -124,6 +128,8 @@
 		F4029F3A2A3B5B4A00ECEABD /* ProductList */ = {
 			isa = PBXGroup;
 			children = (
+				F4029F3B2A3B5CE700ECEABD /* ProductListCollectionView.swift */,
+				F4029F3C2A3B5CE700ECEABD /* ProductListDataSource.swift */,
 				F4029F372A3B5B4500ECEABD /* LoadCollectionViewCell.swift */,
 				F4029F362A3B5B4500ECEABD /* ProductListCollectionViewCell.swift */,
 			);
@@ -275,6 +281,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F4029F3E2A3B5CE700ECEABD /* ProductListDataSource.swift in Sources */,
 				4FE271522A31B23A0002AE35 /* ImageMapper.swift in Sources */,
 				F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */,
 				F4029F382A3B5B4500ECEABD /* ProductListCollectionViewCell.swift in Sources */,
@@ -287,6 +294,7 @@
 				F4029F2E2A3B56D300ECEABD /* PaddedLabel.swift in Sources */,
 				F4029F2C2A3B56CB00ECEABD /* BorderView.swift in Sources */,
 				F4029F322A3B571300ECEABD /* ProductState.swift in Sources */,
+				F4029F3D2A3B5CE700ECEABD /* ProductListCollectionView.swift in Sources */,
 				F4029F272A3B557500ECEABD /* UILabel+style.swift in Sources */,
 				F4029F212A3B54D200ECEABD /* Radius.swift in Sources */,
 				F4029F392A3B5B4500ECEABD /* LoadCollectionViewCell.swift in Sources */,

--- a/ios/Daangn/Daangn.xcodeproj/project.pbxproj
+++ b/ios/Daangn/Daangn.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		4FE271522A31B23A0002AE35 /* ImageMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE271512A31B23A0002AE35 /* ImageMapper.swift */; };
 		4FE271542A31C0F50002AE35 /* ColorStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE271532A31C0F50002AE35 /* ColorStyle.swift */; };
 		4FE271562A31C4820002AE35 /* FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE271552A31C4820002AE35 /* FontStyle.swift */; };
+		F4029F212A3B54D200ECEABD /* Radius.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F202A3B54D200ECEABD /* Radius.swift */; };
+		F4029F232A3B54F800ECEABD /* UIView+Radius.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4029F222A3B54F800ECEABD /* UIView+Radius.swift */; };
 		F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C12A305FAF00609856 /* AppDelegate.swift */; };
 		F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49F98C32A305FAF00609856 /* SceneDelegate.swift */; };
 		F49F98CB2A305FB000609856 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F49F98CA2A305FB000609856 /* Assets.xcassets */; };
@@ -22,6 +24,8 @@
 		4FE271512A31B23A0002AE35 /* ImageMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageMapper.swift; sourceTree = "<group>"; };
 		4FE271532A31C0F50002AE35 /* ColorStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStyle.swift; sourceTree = "<group>"; };
 		4FE271552A31C4820002AE35 /* FontStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontStyle.swift; sourceTree = "<group>"; };
+		F4029F202A3B54D200ECEABD /* Radius.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Radius.swift; sourceTree = "<group>"; };
+		F4029F222A3B54F800ECEABD /* UIView+Radius.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Radius.swift"; sourceTree = "<group>"; };
 		F49F98BE2A305FAF00609856 /* Daangn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Daangn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F49F98C12A305FAF00609856 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F49F98C32A305FAF00609856 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -62,6 +66,22 @@
 			path = Literal;
 			sourceTree = "<group>";
 		};
+		F4029F242A3B54FB00ECEABD /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				F4029F222A3B54F800ECEABD /* UIView+Radius.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		F4029F252A3B550900ECEABD /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				F4029F202A3B54D200ECEABD /* Radius.swift */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
 		F49F98B52A305FAF00609856 = {
 			isa = PBXGroup;
 			children = (
@@ -85,6 +105,8 @@
 				4FE2714F2A31B1FA0002AE35 /* Global */,
 				F49F98D62A30629600609856 /* Resource */,
 				F49F98D52A30626000609856 /* Supporting Files */,
+				F4029F252A3B550900ECEABD /* Common */,
+				F4029F242A3B54FB00ECEABD /* Extension */,
 			);
 			path = Daangn;
 			sourceTree = "<group>";
@@ -204,8 +226,10 @@
 			files = (
 				4FE271522A31B23A0002AE35 /* ImageMapper.swift in Sources */,
 				F49F98C22A305FAF00609856 /* AppDelegate.swift in Sources */,
+				F4029F232A3B54F800ECEABD /* UIView+Radius.swift in Sources */,
 				F49F98C42A305FAF00609856 /* SceneDelegate.swift in Sources */,
 				F4AEA7F42A3617D200B00B03 /* TabBarController.swift in Sources */,
+				F4029F212A3B54D200ECEABD /* Radius.swift in Sources */,
 				4FE271542A31C0F50002AE35 /* ColorStyle.swift in Sources */,
 				4FE271562A31C4820002AE35 /* FontStyle.swift in Sources */,
 			);

--- a/ios/Daangn/Daangn/CategoryFilter/CategoryFilterCollectionView.swift
+++ b/ios/Daangn/Daangn/CategoryFilter/CategoryFilterCollectionView.swift
@@ -1,0 +1,30 @@
+//
+//  CategoryFilterCollectionView.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+final class CategoryFilterCollectionView: UICollectionView {
+    typealias Cell = CategoryFilterCollectionViewCell
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        return nil
+    }
+    
+    init() {
+        super.init(frame: .zero, collectionViewLayout: .createList())
+        set()
+    }
+    
+    private func set() {
+        translatesAutoresizingMaskIntoConstraints = false
+        collectionViewLayout = UICollectionViewLayout.createHorizontal()
+        register(Cell.self, forCellWithReuseIdentifier: "\(Cell.self)")
+        
+        alwaysBounceVertical = false
+    }
+}

--- a/ios/Daangn/Daangn/CategoryFilter/CategoryFilterCollectionViewCell.swift
+++ b/ios/Daangn/Daangn/CategoryFilter/CategoryFilterCollectionViewCell.swift
@@ -1,0 +1,67 @@
+//
+//  CategoryFilterCollectionViewCell.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+final class CategoryFilterCollectionViewCell: UICollectionViewCell {
+    private let label: PillShapePaddedLabel = {
+        let label = PillShapePaddedLabel(inset: .init(top: 8, left: 16, bottom: 8, right: 16))
+        label.layer.borderColor = UIColor.systemGray5.cgColor
+        label.applyStyle(font: FontStyle.caption1, color: ColorStyle.black)
+        return label
+    }()
+    
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                setSelected()
+            } else {
+                setDeselected()
+            }
+        }
+    }
+    
+    // MARK: Initializers
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setLabel()
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setLabel()
+    }
+    
+    private func setLabel() {
+        contentView.preservesSuperviewLayoutMargins = false
+        contentView.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            label.topAnchor.constraint(equalTo: contentView.topAnchor),
+            label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+        ])
+        setDeselected()
+    }
+    
+    private func setSelected() {
+        label.backgroundColor = ColorStyle.orange
+        label.layer.borderWidth = 0
+        label.textColor = ColorStyle.white
+    }
+    
+    private func setDeselected() {
+        label.backgroundColor = ColorStyle.white
+        label.layer.borderWidth = 1
+        label.textColor = ColorStyle.black
+    }
+    
+    func configure(text: String) {
+        label.text = text
+    }
+}

--- a/ios/Daangn/Daangn/CategoryFilter/CateogryFilterDataSource.swift
+++ b/ios/Daangn/Daangn/CategoryFilter/CateogryFilterDataSource.swift
@@ -1,0 +1,30 @@
+//
+//  CateogryFilterDataSource.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/15.
+//
+
+import UIKit
+
+enum FilterSection {
+    case category
+}
+
+final class CateogryFilterDataSource: UICollectionViewDiffableDataSource<FilterSection, Category> {
+    typealias CollectionView = CategoryFilterCollectionView
+    typealias Cell = CategoryFilterCollectionViewCell
+    
+    static let cellProvider: CellProvider = { collectionView, indexPath, itemIdentifier in
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: "\(Cell.self)",
+            for: indexPath
+        ) as? Cell else { return UICollectionViewCell() }
+        cell.configure(text: itemIdentifier.korean)
+        return cell
+    }
+    
+    convenience init(_ collectionView: CollectionView) {
+        self.init(collectionView: collectionView, cellProvider: Self.cellProvider)
+    }
+}

--- a/ios/Daangn/Daangn/Common/Radius.swift
+++ b/ios/Daangn/Daangn/Common/Radius.swift
@@ -1,0 +1,12 @@
+//
+//  Radius.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/15.
+//
+
+import UIKit
+
+enum Radius: CGFloat {
+    case roundedRectangle = 8
+}

--- a/ios/Daangn/Daangn/Component/BorderView.swift
+++ b/ios/Daangn/Daangn/Component/BorderView.swift
@@ -1,0 +1,26 @@
+//
+//  BorderView.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/15.
+//
+
+import UIKit
+
+final class Boarder: UIView {
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        return nil
+    }
+    
+    init() {
+        super.init(frame: .zero)
+        set()
+    }
+    
+    private func set() {
+        backgroundColor = ColorStyle.gray600
+        translatesAutoresizingMaskIntoConstraints = false
+        heightAnchor.constraint(equalToConstant: 1).isActive = true
+    }
+}

--- a/ios/Daangn/Daangn/Component/PaddedLabel.swift
+++ b/ios/Daangn/Daangn/Component/PaddedLabel.swift
@@ -1,0 +1,53 @@
+//
+//  PillShapeLabel.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+class PaddedLabel: UILabel {
+    var inset: UIEdgeInsets
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        return nil
+    }
+    
+    init(inset: UIEdgeInsets) {
+        self.inset = inset
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: inset))
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        var contentSize = super.intrinsicContentSize
+        contentSize.height += inset.top + inset.bottom
+        contentSize.width += inset.left + inset.right
+        return contentSize
+    }
+}
+
+class RoundedPaddedLabel: PaddedLabel {
+    init(radius: Radius, inset: UIEdgeInsets) {
+        super.init(inset: inset)
+        setRadius(radius: .roundedRectangle)
+    }
+}
+
+final class PillShapePaddedLabel: PaddedLabel {
+    // TODO: layoutSubviews 대안 찾기
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        setRadius()
+    }
+    
+    func setRadius() {
+        setRadius(constant: frame.height / 2)
+    }
+}

--- a/ios/Daangn/Daangn/Component/ProductListImageView.swift
+++ b/ios/Daangn/Daangn/Component/ProductListImageView.swift
@@ -1,0 +1,27 @@
+//
+//  ProductListImageView.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+final class ProductListImageView: UIImageView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        set()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        set()
+    }
+    
+    private func set() {
+        layer.borderColor = ColorStyle.gray600?.cgColor
+        layer.borderWidth = 1
+        setRadius(radius: .roundedRectangle)
+        translatesAutoresizingMaskIntoConstraints = false
+    }
+}

--- a/ios/Daangn/Daangn/Component/ProductStateBadge.swift
+++ b/ios/Daangn/Daangn/Component/ProductStateBadge.swift
@@ -1,0 +1,26 @@
+//
+//  ProductStateBadge.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+final class ProductStateBadge: RoundedPaddedLabel {
+    private static let edgeInset = UIEdgeInsets(top: 3, left: 8, bottom: 3, right: 8)
+    
+    override init(radius: Radius, inset: UIEdgeInsets) {
+        super.init(radius: radius, inset: Self.edgeInset)
+        set()
+    }
+    
+    private func set() {
+        applyStyle(font: FontStyle.caption1, color: ColorStyle.white)
+    }
+    
+    func configure(state: ProductState) {
+        self.text = state.korean
+        self.backgroundColor = state.color
+    }
+}

--- a/ios/Daangn/Daangn/Extension/CollectionViewLayout+layouts.swift
+++ b/ios/Daangn/Daangn/Extension/CollectionViewLayout+layouts.swift
@@ -9,13 +9,12 @@ import UIKit
 
 extension UICollectionViewLayout {
     static func createHorizontal() -> UICollectionViewCompositionalLayout {
-        let sectionProvider: UICollectionViewCompositionalLayoutSectionProvider = { _, environment in
+        let sectionProvider: UICollectionViewCompositionalLayoutSectionProvider = { _, _ in
             let layoutSize = NSCollectionLayoutSize(widthDimension: .estimated(100), heightDimension: .fractionalHeight(1))
             let item = NSCollectionLayoutItem(layoutSize: layoutSize)
             
             let groupSize = NSCollectionLayoutSize(widthDimension: .estimated(100), heightDimension: .absolute(32))
-            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
-                                                           subitems: [item])
+            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
             
             let section = NSCollectionLayoutSection(group: group)
             section.orthogonalScrollingBehavior = .continuous

--- a/ios/Daangn/Daangn/Extension/CollectionViewLayout+layouts.swift
+++ b/ios/Daangn/Daangn/Extension/CollectionViewLayout+layouts.swift
@@ -1,0 +1,37 @@
+//
+//  CollectionViewLayout+layouts.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+extension UICollectionViewLayout {
+    static func createHorizontal() -> UICollectionViewCompositionalLayout {
+        let sectionProvider: UICollectionViewCompositionalLayoutSectionProvider = { _, environment in
+            let layoutSize = NSCollectionLayoutSize(widthDimension: .estimated(100), heightDimension: .fractionalHeight(1))
+            let item = NSCollectionLayoutItem(layoutSize: layoutSize)
+            
+            let groupSize = NSCollectionLayoutSize(widthDimension: .estimated(100), heightDimension: .absolute(32))
+            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
+                                                           subitems: [item])
+            
+            let section = NSCollectionLayoutSection(group: group)
+            section.orthogonalScrollingBehavior = .continuous
+            section.interGroupSpacing = 4
+            section.contentInsets = .init(top: 16, leading: 16, bottom: 0, trailing: 16)
+            return section
+        }
+        return UICollectionViewCompositionalLayout(sectionProvider: sectionProvider)
+    }
+    
+    static func createList() -> UICollectionViewCompositionalLayout {
+        let sectionProvider: UICollectionViewCompositionalLayoutSectionProvider = { _, environment in
+            var config = UICollectionLayoutListConfiguration(appearance: .plain)
+            config.showsSeparators = true
+            return NSCollectionLayoutSection.list(using: config, layoutEnvironment: environment)
+        }
+        return UICollectionViewCompositionalLayout(sectionProvider: sectionProvider)
+    }
+}

--- a/ios/Daangn/Daangn/Extension/UILabel+style.swift
+++ b/ios/Daangn/Daangn/Extension/UILabel+style.swift
@@ -1,0 +1,15 @@
+//
+//  UILabel+style.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+extension UILabel {
+    func applyStyle(font: UIFont, color: UIColor) {
+        self.font = font
+        self.textColor = color
+    }
+}

--- a/ios/Daangn/Daangn/Extension/UILabel+style.swift
+++ b/ios/Daangn/Daangn/Extension/UILabel+style.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension UILabel {
-    func applyStyle(font: UIFont, color: UIColor) {
+    func applyStyle(font: UIFont, color: UIColor?) {
         self.font = font
         self.textColor = color
     }

--- a/ios/Daangn/Daangn/Extension/UIView+Radius.swift
+++ b/ios/Daangn/Daangn/Extension/UIView+Radius.swift
@@ -1,0 +1,19 @@
+//
+//  UIView+Radius.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/15.
+//
+
+import UIKit
+
+extension UIView {
+    func setRadius(constant: CGFloat) {
+        layer.cornerRadius = constant
+        layer.masksToBounds = true
+    }
+    
+    func setRadius(radius: Radius) {
+        setRadius(constant: radius.rawValue)
+    }
+}

--- a/ios/Daangn/Daangn/Model/Category.swift
+++ b/ios/Daangn/Daangn/Model/Category.swift
@@ -1,0 +1,54 @@
+//
+//  Category.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/15.
+//
+
+import Foundation
+
+enum Category: Int, CaseIterable {
+    case all = 0
+    case digitalDevice
+    case lifeDevice
+    case furniture
+    case kitchen
+    case baby
+    case childrenBook
+    case womenCloth
+    case womenAccessories
+    case menFashion
+    case cosmetic
+    case sports
+    case gameAndAlbum
+    case car
+    case ticket
+    case food
+    case pet
+    case plant
+    case etc
+
+    var korean: String {
+        switch self {
+        case .all: return "모든 카테고리"
+        case .digitalDevice: return "디지털기기"
+        case .lifeDevice: return "생활가전"
+        case .furniture: return "가구/인테리어"
+        case .kitchen: return "생활/주방"
+        case .baby: return "유아동"
+        case .childrenBook: return "유아도서"
+        case .womenCloth: return "여성의류"
+        case .womenAccessories: return "여성잡화"
+        case .menFashion: return "남성패션/잡화"
+        case .cosmetic: return "뷰티/미용"
+        case .sports: return "스포츠"
+        case .gameAndAlbum: return "게임"
+        case .car: return "중고차"
+        case .ticket: return "티켓"
+        case .food: return "가공식품"
+        case .pet: return "반려동물"
+        case .plant: return "식물"
+        case .etc: return "기타"
+        }
+    }
+}

--- a/ios/Daangn/Daangn/Model/ProductState.swift
+++ b/ios/Daangn/Daangn/Model/ProductState.swift
@@ -1,0 +1,30 @@
+//
+//  ProductState.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+enum ProductState {
+    case sold
+    case selling
+    case reserved
+    
+    var korean: String {
+        switch self {
+        case .sold: return "판매완료"
+        case .selling: return "판매중"
+        case .reserved: return "예약중"
+        }
+    }
+    
+    var color: UIColor? {
+        switch self {
+        case .sold: return ColorStyle.gray700
+        case .selling: return ColorStyle.orange
+        case .reserved: return ColorStyle.mint
+        }
+    }
+}

--- a/ios/Daangn/Daangn/ProductList/LoadCollectionViewCell.swift
+++ b/ios/Daangn/Daangn/ProductList/LoadCollectionViewCell.swift
@@ -1,0 +1,39 @@
+//
+//  LoadCollectionCollectionViewCell.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/13.
+//
+
+import UIKit
+
+final class LoadCollectionViewCell: UICollectionViewCell {
+    static let cellHeight: CGFloat = 40
+    
+    private let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(frame: .zero)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.startAnimating()
+        return indicator
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        set()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        set()
+    }
+    
+    private func set() {
+        contentView.addSubview(activityIndicator)
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            activityIndicator.widthAnchor.constraint(equalToConstant: Self.cellHeight),
+            activityIndicator.heightAnchor.constraint(equalTo: contentView.widthAnchor),
+        ])
+    }
+}

--- a/ios/Daangn/Daangn/ProductList/ProductListCollectionView.swift
+++ b/ios/Daangn/Daangn/ProductList/ProductListCollectionView.swift
@@ -1,0 +1,29 @@
+//
+//  ProductListCollectionView.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+final class ProductListCollectionView: UICollectionView {
+    typealias ProductCell = ProductListCollectionViewCell
+    typealias LoadCell = LoadCollectionViewCell
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        return nil
+    }
+    
+    init() {
+        super.init(frame: .zero, collectionViewLayout: .createList())
+        set()
+    }
+    
+    private func set() {
+        translatesAutoresizingMaskIntoConstraints = false
+        register(ProductCell.self, forCellWithReuseIdentifier: "\(ProductCell.self)")
+        register(LoadCell.self, forCellWithReuseIdentifier: "\(LoadCell.self)")
+    }
+}

--- a/ios/Daangn/Daangn/ProductList/ProductListCollectionViewCell.swift
+++ b/ios/Daangn/Daangn/ProductList/ProductListCollectionViewCell.swift
@@ -148,9 +148,7 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
             productImage.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
             productImage.heightAnchor.constraint(equalToConstant: 120),
             productImage.widthAnchor.constraint(equalTo: productImage.heightAnchor),
-            
         ])
-        
         let imageBottomConstraint = productImage.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor)
         imageBottomConstraint.priority = .defaultHigh
         imageBottomConstraint.isActive = true
@@ -162,7 +160,6 @@ final class ProductListCollectionViewCell: UICollectionViewCell {
             informationStack.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor, constant: 4),
         ])
         
-        // chat heart stack
         contentView.addSubview(chatHeartStack)
         NSLayoutConstraint.activate([
             chatHeartStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),

--- a/ios/Daangn/Daangn/ProductList/ProductListCollectionViewCell.swift
+++ b/ios/Daangn/Daangn/ProductList/ProductListCollectionViewCell.swift
@@ -1,0 +1,214 @@
+//
+//  ProductListCollectionViewCell.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/12.
+//
+
+import UIKit
+
+final class ProductListCollectionViewCell: UICollectionViewCell {
+    // MARK: Views
+    
+    private let productImage: ProductListImageView = ProductListImageView(frame: .zero)
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        label.applyStyle(font: FontStyle.subhead, color: ColorStyle.gray900)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let button: UIButton = {
+        let button = UIButton(frame: .zero)
+        button.setImage(UIImage(systemName: "ellipsis"), for: .normal)
+        button.tintColor = ColorStyle.gray800
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.widthAnchor.constraint(equalToConstant: 17).isActive = true
+        
+        button.addTarget(nil, action: #selector(tapped), for: .touchUpInside)
+        
+        return button
+    }()
+    
+    private lazy var titleButtonStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [titleLabel, button])
+        stack.axis = .horizontal
+        stack.spacing = 2
+        stack.distribution = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.heightAnchor.constraint(equalToConstant: 20).isActive = true
+        return stack
+    }()
+    
+    private let locationLabel: UILabel = ProductListCollectionViewCell.footnoteLabelMaker(nil)
+    
+    private let dotLabel: UILabel = ProductListCollectionViewCell.footnoteLabelMaker("・")
+    
+    private let timeStampLabel: UILabel = ProductListCollectionViewCell.footnoteLabelMaker(nil)
+    
+    private let stateBadge: ProductStateBadge = ProductStateBadge(radius: .roundedRectangle, inset: .init())
+    
+    private let priceLabel: UILabel = {
+        let label = UILabel(frame: .zero)
+        label.applyStyle(font: FontStyle.headline, color: ColorStyle.gray900)
+        label.textColor = ColorStyle.black
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var informationStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [titleButtonStack, locationTimeStack, statePriceStack])
+        stack.axis = .vertical
+        stack.spacing = 4
+        stack.distribution = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+    
+    private lazy var locationTimeStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [locationLabel, dotLabel, timeStampLabel, UIView()])
+        stack.axis = .horizontal
+        stack.spacing = 2
+        stack.distribution = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.heightAnchor.constraint(equalToConstant: 18).isActive = true
+        return stack
+    }()
+    
+    private lazy var statePriceStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [stateBadge, priceLabel, UIView()])
+        stack.axis = .horizontal
+        stack.spacing = 4
+        stack.distribution = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+    
+    private let chatIcon: UIImageView = iconImageViewMaker("message")
+    
+    private let chatCountLabel: UILabel = ProductListCollectionViewCell.footnoteLabelMaker(nil)
+    
+    private let heartIcon: UIImageView = iconImageViewMaker("heart")
+    
+    private let heartCountLabel: UILabel = ProductListCollectionViewCell.footnoteLabelMaker(nil)
+    
+    private lazy var chatStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [chatIcon, chatCountLabel])
+        stack.axis = .horizontal
+        stack.spacing = 2
+        stack.distribution = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+    
+    private lazy var heartStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [heartIcon, heartCountLabel])
+        stack.axis = .horizontal
+        stack.spacing = 2
+        stack.distribution = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+    
+    private lazy var chatHeartStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [chatStack, heartStack])
+        stack.axis = .horizontal
+        stack.spacing = 4
+        stack.distribution = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+    
+    // MARK: Initializers
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setMargin()
+        setLayout()
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setMargin()
+        setLayout()
+    }
+    
+    // MARK: Instance Methods
+    
+    private func setMargin() {
+        contentView.directionalLayoutMargins = .init(top: 15, leading: 16, bottom: 15, trailing: 16)
+        contentView.preservesSuperviewLayoutMargins = false
+    }
+    
+    private func setLayout() {
+        contentView.addSubview(productImage)
+        NSLayoutConstraint.activate([
+            productImage.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
+            productImage.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
+            productImage.heightAnchor.constraint(equalToConstant: 120),
+            productImage.widthAnchor.constraint(equalTo: productImage.heightAnchor),
+            
+        ])
+        
+        let imageBottomConstraint = productImage.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor)
+        imageBottomConstraint.priority = .defaultHigh
+        imageBottomConstraint.isActive = true
+        
+        contentView.addSubview(informationStack)
+        NSLayoutConstraint.activate([
+            informationStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            informationStack.leadingAnchor.constraint(equalTo: productImage.trailingAnchor, constant: 15),
+            informationStack.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor, constant: 4),
+        ])
+        
+        // chat heart stack
+        contentView.addSubview(chatHeartStack)
+        NSLayoutConstraint.activate([
+            chatHeartStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
+            chatHeartStack.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor, constant: -4),
+            chatHeartStack.heightAnchor.constraint(equalToConstant: 20),
+        ])
+    }
+    
+    @objc func tapped() {
+        print("tap")
+    }
+}
+
+extension ProductListCollectionViewCell {
+    // MARK: Cell Configure
+    
+    func configure() {
+        productImage.image = UIImage(named: "")
+        titleLabel.text = "글 제목"
+        locationLabel.text = "역삼동"
+        timeStampLabel.text = "2시간 전"
+        stateBadge.configure(state: .reserved)
+        priceLabel.text = "24,500원"
+        
+        chatCountLabel.text = "0"
+        heartCountLabel.text = "0"
+    }
+}
+
+extension ProductListCollectionViewCell {
+    // MARK: Static Properties
+
+    private static let footnoteLabelMaker: (String?) -> UILabel = { text in
+        let label = UILabel(frame: .zero)
+        label.text = text
+        label.applyStyle(font: FontStyle.footnote, color: ColorStyle.gray900)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }
+
+    private static let iconImageViewMaker: (String) -> UIImageView = { symbolName in
+        let imageView = UIImageView(image: UIImage(systemName: symbolName))
+        imageView.tintColor = ColorStyle.gray900
+        imageView.preferredSymbolConfiguration = .init(scale: .small)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }
+
+}

--- a/ios/Daangn/Daangn/ProductList/ProductListDataSource.swift
+++ b/ios/Daangn/Daangn/ProductList/ProductListDataSource.swift
@@ -1,0 +1,48 @@
+//
+//  ProductListDataSource.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+enum ProductListSection {
+    case product
+    case load
+}
+
+enum ProductListItem: Hashable {
+    // TODO: Int > Product 타입으로 교체
+    case product(Int)
+    case load
+}
+
+final class ProductListDataSource: UICollectionViewDiffableDataSource<ProductListSection, ProductListItem> {
+    typealias ProductCell = ProductListCollectionViewCell
+    typealias LoadCell = LoadCollectionViewCell
+    
+    static let cellProvider: CellProvider = { collectionView, indexPath, itemIdentifier in
+        switch itemIdentifier {
+        case .product:
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: "\(ProductCell.self)",
+                for: indexPath
+            ) as? ProductCell else { return UICollectionViewCell() }
+            cell.configure()
+            return cell
+        case .load:
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: "\(LoadCell.self)",
+                for: indexPath
+            ) as? LoadCell else { return UICollectionViewCell() }
+            return cell
+        }
+    }
+    
+    typealias CollectionView = ProductListCollectionView
+    
+    convenience init(_ collectionView: CollectionView) {
+        self.init(collectionView: collectionView, cellProvider: Self.cellProvider)
+    }
+}

--- a/ios/Daangn/Daangn/TempVC/TempHomeViewController.swift
+++ b/ios/Daangn/Daangn/TempVC/TempHomeViewController.swift
@@ -1,0 +1,39 @@
+//
+//  TempHomeViewController.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+class TempHomeViewController: UIViewController {
+    private let collectionView = ProductListCollectionView()
+    private lazy var dataSource: ProductListDataSource? = ProductListDataSource(collectionView)
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setLayout()
+        applyUpdatedSnapshot()
+    }
+    
+    private func setLayout() {
+        view.addSubview(collectionView)
+        NSLayoutConstraint.activate([
+            collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+        ])
+    }
+    
+    private func applyUpdatedSnapshot() {
+        var snapshot = NSDiffableDataSourceSnapshot<ProductListSection, ProductListItem>()
+        snapshot.appendSections([.product, .load])
+        // TODO: 임시 코드 수정
+        let products = (1...100).map { ProductListItem.product($0) }
+        snapshot.appendItems(products, toSection: .product)
+        if true { snapshot.appendItems([.load], toSection: .load) }
+        dataSource?.apply(snapshot, animatingDifferences: true)
+    }
+}

--- a/ios/Daangn/Daangn/TempVC/TempSalesViewController.swift
+++ b/ios/Daangn/Daangn/TempVC/TempSalesViewController.swift
@@ -1,0 +1,77 @@
+//
+//  TempSalesViewController.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+class TempSalesViewController: UIViewController {
+    private let collectionView = ProductListCollectionView()
+    private lazy var dataSource: ProductListDataSource? = ProductListDataSource(collectionView)
+    
+    private let segementedControl: UISegmentedControl = {
+        let control = UISegmentedControl(items: ["판매중", "판매완료"])
+        control.selectedSegmentIndex = 0
+        control.translatesAutoresizingMaskIntoConstraints = false
+        return control
+    }()
+    
+    private lazy var segementedControlContainer: UIView = {
+        let container = UIView(frame: .zero)
+        container.addSubview(segementedControl)
+        NSLayoutConstraint.activate([
+            segementedControl.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+            segementedControl.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            segementedControl.widthAnchor.constraint(equalToConstant: 240),
+        ])
+        container.translatesAutoresizingMaskIntoConstraints = false
+        return container
+    }()
+    
+    private lazy var stack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [
+            segementedControlContainer,
+            Boarder(),
+            collectionView,
+        ])
+        stack.axis = .vertical
+        stack.spacing = 0
+        stack.distribution = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.title = "판매 내역"
+        setLayout()
+        applyUpdatedSnapshot()
+    }
+    
+    private func setLayout() {
+        view.addSubview(segementedControlContainer)
+        NSLayoutConstraint.activate([
+            segementedControlContainer.heightAnchor.constraint(equalToConstant: 56),
+        ])
+        
+        view.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+        ])
+    }
+    
+    private func applyUpdatedSnapshot() {
+        var snapshot = NSDiffableDataSourceSnapshot<ProductListSection, ProductListItem>()
+        snapshot.appendSections([.product, .load])
+        // TODO: 임시 코드 수정
+        let products = (1...100).map { ProductListItem.product($0) }
+        snapshot.appendItems(products, toSection: .product)
+        if true { snapshot.appendItems([.load], toSection: .load) }
+        dataSource?.apply(snapshot, animatingDifferences: true)
+    }
+}

--- a/ios/Daangn/Daangn/TempVC/TempTabBarController.swift
+++ b/ios/Daangn/Daangn/TempVC/TempTabBarController.swift
@@ -1,0 +1,43 @@
+//
+//  TempTabBarController.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/15.
+//
+
+import UIKit
+
+class TempTabBarController: UITabBarController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .systemBackground
+        setViewControllers()
+    }
+    
+    func setViewControllers() {
+        let homeVC = TempHomeViewController()
+        let homeNavi = UINavigationController(rootViewController: homeVC)
+        homeNavi.navigationBar.prefersLargeTitles = false
+        homeNavi.tabBarItem.title = "판매내역"
+        homeNavi.tabBarItem.image = UIImage(systemName: "house")
+        
+        let productListVC = TempSalesViewController()
+        let productNavi = UINavigationController(rootViewController: productListVC)
+        productNavi.navigationBar.prefersLargeTitles = false
+        productNavi.tabBarItem.title = "판매내역"
+        productNavi.tabBarItem.image = UIImage(systemName: "pencil")
+        
+        let wishlistVC = TempWishListViewController()
+        let wishNavi = UINavigationController(rootViewController: wishlistVC)
+        wishNavi.navigationBar.prefersLargeTitles = false
+        wishNavi.tabBarItem.title = "관심목록"
+        wishNavi.tabBarItem.image = UIImage(systemName: "heart")
+        
+        let controllers = [
+            homeNavi,
+            productNavi,
+            wishNavi,
+        ]
+        setViewControllers(controllers, animated: false)
+    }
+}

--- a/ios/Daangn/Daangn/TempVC/TempWishListViewController.swift
+++ b/ios/Daangn/Daangn/TempVC/TempWishListViewController.swift
@@ -1,0 +1,72 @@
+//
+//  WishListViewController.swift
+//  temp-uikit-layout
+//
+//  Created by Effie on 2023/06/14.
+//
+
+import UIKit
+
+class TempWishListViewController: UIViewController {
+    typealias FilterCell = CategoryFilterCollectionViewCell
+    
+    private let filterCollectionView = CategoryFilterCollectionView()
+    private lazy var filterDataSource: CateogryFilterDataSource? = CateogryFilterDataSource(filterCollectionView)
+    private let productCollectionView = ProductListCollectionView()
+    private lazy var productListDataSource: ProductListDataSource? = ProductListDataSource(productCollectionView)
+    
+    private lazy var collectionViewStack: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [
+            Boarder(),
+            filterCollectionView,
+            productCollectionView
+        ])
+        stack.axis = .vertical
+        stack.spacing = 0
+        stack.distribution = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.title = "관심 목록"
+        setLayout()
+        setFilter()
+        applyUpdatedSnapshot()
+    }
+    
+    private func setLayout() {
+        view.addSubview(filterCollectionView)
+        NSLayoutConstraint.activate([
+            filterCollectionView.heightAnchor.constraint(equalToConstant: 56),
+        ])
+        
+        view.addSubview(collectionViewStack)
+        NSLayoutConstraint.activate([
+            collectionViewStack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            collectionViewStack.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            collectionViewStack.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            collectionViewStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+        ])
+    }
+    
+    private func setFilter() {
+        var snapshot = NSDiffableDataSourceSnapshot<FilterSection, Category>()
+        snapshot.appendSections([.category])
+        snapshot.appendItems(Category.allCases, toSection: .category)
+        filterDataSource?.apply(snapshot, animatingDifferences: true)
+        
+        filterCollectionView.selectItem(at: IndexPath(item: 0, section: 0), animated: false, scrollPosition: .left)
+    }
+    
+    private func applyUpdatedSnapshot() {
+        var snapshot = NSDiffableDataSourceSnapshot<ProductListSection, ProductListItem>()
+        snapshot.appendSections([.product, .load])
+        // TODO: 임시 코드 수정
+        let products = (1...100).map { ProductListItem.product($0) }
+        snapshot.appendItems(products, toSection: .product)
+        if true { snapshot.appendItems([.load], toSection: .load) }
+        productListDataSource?.apply(snapshot, animatingDifferences: true)
+    }
+}


### PR DESCRIPTION
홈 화면 상품 목록, 판매 내역 목록, 관심 상품 목록에 공통으로 사용되는 collection view 및 관련 view controller 를 작성했습니다.

- view extension 작성
- view 컴포넌트 타입 작성
- 상품 목록 공통 collection view 및 관련 cell 및 data source 작성
- 관심 상품 목록 화면의 카테고리 필터 collection view 및 관련 타입 작성
- 구현에 필요한 모델 작성
- 3개 화면 임시 view collection view 작성

확인 사항
- merge 이후 기존 view controller 구현과 병합 및 수정 예정입니다.